### PR TITLE
Add Confluence Forge example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -166,6 +166,7 @@ See [tests/Readme.md](tests/Readme.md) for more information.
 - [Networking between browser windows/tabs using the Broadcast Channel API](examples/broadcast-network.html)
 - [TCP Terminal (fetch-based networking)](examples/tcp_terminal.html)
 - [Saving and restoring emulator state](examples/save_restore.html)
+- [Forge app example](forge-example/README.md)
 
 Using v86 for your own purposes is as easy as:
 

--- a/forge-example/README.md
+++ b/forge-example/README.md
@@ -1,0 +1,5 @@
+# Forge example
+
+This directory contains a minimal Atlassian Forge app that embeds the `v86` WASM PC emulator in a Confluence macro.
+
+The `static/index.html` page loads `libv86.js` from a CDN and starts an instance using the provided BIOS and disk images. See `manifest.yml` for the module definitions.

--- a/forge-example/manifest.yml
+++ b/forge-example/manifest.yml
@@ -1,0 +1,20 @@
+modules:
+  confluence:macro:
+    - key: wasm-emulator
+      resource: main
+      resolver:
+        function: resolver
+      render: native
+      title: WASM Emulator
+      description: Run a PC emulator inside Confluence
+  function:
+    - key: resolver
+      handler: index.handler
+resources:
+  - key: main
+    path: static
+app:
+  id: ari:cloud:ecosystem::app-template-id
+permissions:
+  scopes:
+    - read:confluence-content.summary

--- a/forge-example/src/index.js
+++ b/forge-example/src/index.js
@@ -1,0 +1,10 @@
+import Resolver from '@forge/resolver';
+
+const resolver = new Resolver();
+
+// Basic resolver that simply returns context information.
+resolver.define('getContext', (req) => {
+  return { context: req.context };
+});
+
+export const handler = resolver.getDefinitions();

--- a/forge-example/static/index.html
+++ b/forge-example/static/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Forge WASM Emulator</title>
+    <style>
+      html, body, #screen_container { height: 100%; margin: 0; }
+    </style>
+    <!-- Pre-built v86 from CDN -->
+    <script src="https://cdn.jsdelivr.net/npm/v86@0.5/build/libv86.js"></script>
+  </head>
+  <body>
+    <div id="screen_container"></div>
+    <script>
+      const emulator = new V86({
+        wasm_path: "https://cdn.jsdelivr.net/npm/v86@0.5/build/v86.wasm",
+        bios: { url: "https://copy.sh/v86/bios/seabios.bin" },
+        vga_bios: { url: "https://copy.sh/v86/bios/vgabios.bin" },
+        cdrom: { url: "https://copy.sh/v86/images/linux.iso" },
+        autostart: true,
+        screen_container: document.getElementById('screen_container'),
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- include a minimal Atlassian Forge app
- show how to launch the emulator from a Confluence macro
- link to the example from the main README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68877d61d80083279945ba28b42c01b8